### PR TITLE
Installation note expansion

### DIFF
--- a/modules/lang/org/README.org
+++ b/modules/lang/org/README.org
@@ -191,7 +191,12 @@ brew install gnuplot
 #+begin_src sh
 pacman -S texlive-core texlive-bin texlive-science texlive-latexextra
 pacman -S gnuplot
-pacman -S jupyter # required by +jupyter
+#+end_src
+
+** Debian & Ubuntu
+#+begin_src sh
+apt-get install texlive dvipng
+apt-get install gnuplot
 #+end_src
 
 ** NixOS


### PR DESCRIPTION
Added Debian & Ubuntu section.

Arch Linux no longer has a package called "jupyter".